### PR TITLE
feat: add /progress/ endpoint to show scan progress

### DIFF
--- a/pkg/webapp/webapp.go
+++ b/pkg/webapp/webapp.go
@@ -3,6 +3,7 @@ package webapp
 import (
 	"fmt"
 	"html/template"
+	"encoding/json"
 	"net/http"
 	"sort"
 	"strings"
@@ -375,6 +376,17 @@ func (wa *Webapp) goRunHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (wa *Webapp) progressHandler(w http.ResponseWriter, r *http.Request) {
+	progress := wa.orchestrator.ScanProgress()
+	jsonResp, err := json.Marshal(progress)
+	if err != nil {
+		log.Fatalf("Error happened in JSON marshal. Err: %s", err)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonResp)
+}
+
+
 /******************************************************* PUBLIC *******************************************************/
 
 func Init(config *config.Config, scanConfig *config.ScanConfig) (*Webapp, error) {
@@ -409,6 +421,7 @@ func (wa *Webapp) Run() {
 	http.HandleFunc("/go/run/", wa.goRunHandler)
 	http.HandleFunc("/go/verify/", wa.goVerifyHandler)
 	http.HandleFunc("/go/cancel/", wa.goCancelHandler)
+	http.HandleFunc("/progress/", wa.progressHandler)
 	go func() {
 		if err := http.ListenAndServe(":"+wa.executionConfig.WebappPort, nil); err != nil {
 			errChannel <- fmt.Errorf("failed to start Webapp: %v", err)


### PR DESCRIPTION
This patch adds a new endpoint to kubei's web-app at `/progress/`. It prints `scanner.ScanProgress()` as json.

Example:

```
GET /progress/
{
  "ImagesToScan": 15,
  "ImagesStartedToScan": 13,
  "ImagesCompletedToScan": 2
}
```

This can be useful if you have a script that's waiting for results. That way it can poll this endpoint until all scans completed
