### PR TITLE
fix: move sbom db dockerfile to root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,9 @@ jobs:
     - name: Build SBOM DB
       uses: docker/build-push-action@v2
       with:
-        context: sbom_db
+        context: .
         tags: ghcr.io/cisco-open/kubeclarity-sbom-db:${{ github.sha }}
-        file: sbom_db/Dockerfile.sbom_db
+        file: Dockerfile.sbom_db
         push: false
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,9 +79,9 @@ jobs:
       - name: Build SBOM DB
         uses: docker/build-push-action@v2
         with:
-          context: sbom_db
+          context: .
           tags: ghcr.io/cisco-open/kubeclarity-sbom-db:latest
-          file: sbom_db/Dockerfile.sbom_db
+          file: Dockerfile.sbom_db
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,9 +110,9 @@ jobs:
       - name: Build SBOM DB
         uses: docker/build-push-action@v2
         with:
-          context: sbom_db
+          context: .
           tags: ghcr.io/cisco-open/kubeclarity-sbom-db:${{ github.ref_name }}
-          file: sbom_db/Dockerfile.sbom_db
+          file: Dockerfile.sbom_db
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/Dockerfile.sbom_db
+++ b/Dockerfile.sbom_db
@@ -2,11 +2,11 @@ FROM golang:1.17.3-alpine AS builder
 
 RUN apk add --update --no-cache gcc g++ git
 
-WORKDIR /build
-COPY api ./api
+WORKDIR /build/sbom_db
+COPY sbom_db/api ./api
 
-WORKDIR /build/backend
-COPY backend/go.* ./
+WORKDIR /build/sbom_db/backend
+COPY sbom_db/backend/go.* ./
 RUN go mod download
 
 ARG VERSION
@@ -14,16 +14,16 @@ ARG BUILD_TIMESTAMP
 ARG COMMIT_HASH
 
 # Copy and build backend code
-COPY backend .
+COPY sbom_db/backend .
 RUN go build -ldflags="-s -w \
      -X 'github.com/cisco-open/kubei/sbom_db/backend/pkg/version.Version=${VERSION}' \
      -X 'github.com/cisco-open/kubei/sbom_db/backend/pkg/version.CommitHash=${COMMIT_HASH}' \
      -X 'github.com/cisco-open/kubei/sbom_db/backend/pkg/version.BuildTimestamp=${BUILD_TIMESTAMP}'" -o sbom_db ./cmd/main.go
 
-FROM alpine:3.15.0
+FROM alpine:3.15.4
 
 WORKDIR /app
 
-COPY --from=builder ["/build/backend/sbom_db", "./sbom_db"]
+COPY --from=builder ["/build/sbom_db/backend/sbom_db", "./sbom_db"]
 
 ENTRYPOINT ["/app/sbom_db"]

--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,10 @@ push-docker: push-docker-backend push-docker-cli push-docker-sbom-db push-docker
 .PHONY: docker-sbom-db
 docker-sbom-db: ## Build SBOM DB Backend Docker image
 	@(echo "Building SBOM DB backend docker image ..." )
-	docker build --file ./sbom_db/Dockerfile.sbom_db --build-arg VERSION=${VERSION} \
+	docker build --file ./Dockerfile.sbom_db --build-arg VERSION=${VERSION} \
 		--build-arg BUILD_TIMESTAMP=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
 		--build-arg COMMIT_HASH=$(shell git rev-parse HEAD) \
-		-t ${DOCKER_IMAGE}-sbom-db:${DOCKER_TAG} ./sbom_db
+		-t ${DOCKER_IMAGE}-sbom-db:${DOCKER_TAG} .
 
 .PHONY: push-docker-sbom-db
 push-docker-sbom-db: docker-sbom-db ## Build and Push SBOM DB Backend Docker image


### PR DESCRIPTION
dependabot skipped sbom_db dockerfile updates (see https://github.com/cisco-open/kubei/pull/117) , moving dockerfile to root folder to be with all other dockerfiles.